### PR TITLE
Updated Zenodo codebase link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![arXiv](https://img.shields.io/badge/arXiv-2411.09047-b31b1b.svg)](https://arxiv.org/abs/2411.09047)
 [![dataset DOI](https://img.shields.io/badge/dataset%20DOI-10.5281%2Fzenodo.14062900-blue.svg)](https://doi.org/10.5281/zenodo.14062900)
-[![software DOI](https://img.shields.io/badge/software%20DOI-10.5281%2Fzenodo.14598119-blue.svg)](https://doi.org/10.5281/zenodo.14598118)
+[![software DOI](https://img.shields.io/badge/software%20DOI-10.5281%2Fzenodo.14598118-blue.svg)](https://doi.org/10.5281/zenodo.14598118)
 ![python](https://img.shields.io/badge/python-3.11.0-blue.svg)
 
 


### PR DESCRIPTION
You can cite all versions by using the DOI [10.5281/zenodo.14598118](https://doi.org/10.5281/zenodo.14598118). This DOI represents all versions, and will always resolve to the latest one.